### PR TITLE
An extensible approach for correlation propagation in Asp.Net Core Hosting

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
@@ -18,8 +18,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private readonly IHttpContextFactory _httpContextFactory;
         private HostingApplicationDiagnostics _diagnostics;
 
-        internal static bool IsCorrelationConsumerRegistered = false;
-        internal static List<ICorrelationConsumer> CorrelationConsumers = new List<ICorrelationConsumer>();
+        internal static bool IsCustomCorrelationConsumerRegistered = false;
+        internal static List<ICorrelationConsumer> CorrelationConsumers =
+            new List<ICorrelationConsumer>() { new LegacyActivityCorrelationConsumer() };
 
         public HostingApplication(
             RequestDelegate application,
@@ -63,7 +64,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             if ( correlationConsumer != null )
             {
-                IsCorrelationConsumerRegistered = true;
+                IsCustomCorrelationConsumerRegistered = true;
                 CorrelationConsumers.Add( correlationConsumer );
             }
         }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -16,6 +17,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private readonly RequestDelegate _application;
         private readonly IHttpContextFactory _httpContextFactory;
         private HostingApplicationDiagnostics _diagnostics;
+
+        internal static bool IsCorrelationConsumerRegistered = false;
+        internal static List<ICorrelationConsumer> CorrelationConsumers = new List<ICorrelationConsumer>();
 
         public HostingApplication(
             RequestDelegate application,
@@ -33,7 +37,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             var context = new Context();
             var httpContext = _httpContextFactory.Create(contextFeatures);
-
+            
             _diagnostics.BeginRequest(httpContext, ref context);
 
             context.HttpContext = httpContext;
@@ -53,6 +57,15 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             _diagnostics.RequestEnd(httpContext, exception, context);
             _httpContextFactory.Dispose(httpContext);
             _diagnostics.ContextDisposed(context);
+        }
+
+        public static void RegisterCorrelationConsumer( ICorrelationConsumer correlationConsumer )
+        {
+            if ( correlationConsumer != null )
+            {
+                IsCorrelationConsumerRegistered = true;
+                CorrelationConsumers.Add( correlationConsumer );
+            }
         }
 
         public struct Context

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
@@ -73,15 +73,15 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
             // Let each registered Correlation Consumer know that a request has begun. This will
             // allow those consumers to pull relevant correlation data off the request.
-            IEnumerable<ICorrelationConsumer> correlationConsumers =
-                httpContext.RequestServices.GetService(typeof(IEnumerable<ICorrelationConsumer>))
-                    as IEnumerable<ICorrelationConsumer>;
+            IList<ICorrelationConsumer> correlationConsumers =
+                httpContext.RequestServices?.GetService( typeof( IList<ICorrelationConsumer> ) )
+                    as IList<ICorrelationConsumer>;
 
-            if (correlationConsumers != null)
+            if ( correlationConsumers != null )
             {
-                foreach(ICorrelationConsumer correlationConsumer in correlationConsumers)
+                foreach ( ICorrelationConsumer correlationConsumer in correlationConsumers )
                 {
-                    correlationConsumer.BeginRequest(httpContext, context);
+                    correlationConsumer.BeginRequest( httpContext, context );
                 }
             }
 

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ICorrelationConsumer.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ICorrelationConsumer.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Hosting.Internal
+{
+    public interface ICorrelationConsumer
+    {
+        void BeginRequest( HttpContext httpContext, HostingApplication.Context context );
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting/Internal/LegacyActivityCorrelationConsumer.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/LegacyActivityCorrelationConsumer.cs
@@ -1,0 +1,37 @@
+﻿using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Hosting.Internal
+{
+    internal class LegacyActivityCorrelationConsumer : ICorrelationConsumer
+    {
+        private const string RequestIdHeaderName = "Request-Id";
+        private const string CorrelationContextHeaderName = "Correlation-Context";
+
+        public void BeginRequest( HttpContext httpContext, HostingApplication.Context context )
+        {
+            StringValues requestId;
+            httpContext.Request.Headers.TryGetValue( RequestIdHeaderName, out requestId );
+
+            if ( !StringValues.IsNullOrEmpty( requestId ) )
+            {
+                context.Activity.SetParentId( requestId );
+
+                // We expect baggage to be empty by default
+                // Only very advanced users will be using it in near future, we encourage them to keep baggage small (few items)
+                string[] baggage = httpContext.Request.Headers.GetCommaSeparatedValues( CorrelationContextHeaderName );
+                if ( baggage != StringValues.Empty )
+                {
+                    foreach ( var item in baggage )
+                    {
+                        if ( NameValueHeaderValue.TryParse( item, out var baggageItem ) )
+                        {
+                            context.Activity.AddBaggage( baggageItem.Name.ToString(), baggageItem.Value.ToString() );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ServiceCollectionExtensions.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
 {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ServiceCollectionExtensions.cs
@@ -10,23 +10,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     internal static class ServiceCollectionExtensions
     {
-        public static void AddCorrelationConsumer<T>( this IServiceCollection serviceCollection )
-            where T : ICorrelationConsumer, new()
-        {
-            serviceCollection.TryAddSingleton<IList<ICorrelationConsumer>>(
-                new List<ICorrelationConsumer>() );
-
-            IList<ICorrelationConsumer> correlationConsumerList = serviceCollection.FirstOrDefault(
-                descriptor =>
-                    descriptor.ServiceType == typeof( IList<ICorrelationConsumer> ) )
-                ?.ImplementationInstance as IList<ICorrelationConsumer>;
-
-            if ( correlationConsumerList != null )
-            {
-                correlationConsumerList.Add( new T() );
-            }
-        }
-
         public static IServiceCollection Clone(this IServiceCollection serviceCollection)
         {
             IServiceCollection clone = new ServiceCollection();

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ServiceCollectionExtensions.cs
@@ -1,12 +1,32 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
 {
     internal static class ServiceCollectionExtensions
     {
+        public static void AddCorrelationConsumer<T>( this IServiceCollection serviceCollection )
+            where T : ICorrelationConsumer, new()
+        {
+            serviceCollection.TryAddSingleton<IList<ICorrelationConsumer>>(
+                new List<ICorrelationConsumer>() );
+
+            IList<ICorrelationConsumer> correlationConsumerList = serviceCollection.FirstOrDefault(
+                descriptor =>
+                    descriptor.ServiceType == typeof( IList<ICorrelationConsumer> ) )
+                ?.ImplementationInstance as IList<ICorrelationConsumer>;
+
+            if ( correlationConsumerList != null )
+            {
+                correlationConsumerList.Add( new T() );
+            }
+        }
+
         public static IServiceCollection Clone(this IServiceCollection serviceCollection)
         {
             IServiceCollection clone = new ServiceCollection();


### PR DESCRIPTION
These are the rough changes to allow for an extensible solution of consuming arbitrary correlation IDs from incoming requests. It would be up to the service owner to decide which IDs to read from the incoming Http Request and where to store them (ie- on the created Activity, on the request context, etc). In addition, these changes factor out the existing Request-Id handling and instead leverage the added extensibility point.